### PR TITLE
Minimal patch for #4 (bad reconstruction of named anonymous fn)

### DIFF
--- a/src/clairvoyant/core.clj
+++ b/src/clairvoyant/core.clj
@@ -214,7 +214,7 @@
                      :anonymous? true}
         specs (doall (for [[arglist & body] specs]
                        (trace-fn-spec arglist body trace-data env)))]
-    `(~op ~@specs)))
+    `(~op ~sym ~@specs)))
 
 (defmethods trace-form [`fn 'fn* 'fn]
   [form env]


### PR DESCRIPTION
Theoretically this "leaks" the temporary `gensym`'d name that we give to nameless anonymous fns, but I can't think of any reason that'd actually cause a problem in practice.
