### PR TITLE
Feature/cljs devtools support

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,10 @@ is not necessarily tied to logging to the console or printing to the
 screen. Since the trace values are just data the barrier to creativity
 is low.
 
+An additional tracer that works well with [cljs-devtools]
+(https://github.com/binaryage/cljs-devtools) is included as 
+`clairvoyant.core/cljs-devtools-tracer`.
+
 
 ### Source code transformation
 

--- a/src/clairvoyant/core.cljs
+++ b/src/clairvoyant/core.cljs
@@ -60,6 +60,7 @@
       (list 'fn (symbol name) arglist)
       (list 'fn arglist))))
 
+
 (def default-tracer
   (let [pr-val* (fn pr-val* [x]
                             (cond 
@@ -70,10 +71,10 @@
                               :else x))
         pr-val (fn [x] (pr-str (pr-val* x)))
         log-binding (fn [form init]
-                      (.groupCollapsed js/console "%c%s %c%s" 
-                                       "font-weight:bold;" 
+                      (.groupCollapsed js/console "%c%s %c%s"
+                                       "font-weight:bold;"
                                        (pr-str form)
-                                       "font-weight:normal;" 
+                                       "font-weight:normal;"
                                        (pr-val init)))
         log-exit (fn [exit]
                    (.groupCollapsed js/console "=>" (pr-val exit))

--- a/src/clairvoyant/core.cljs
+++ b/src/clairvoyant/core.cljs
@@ -62,21 +62,23 @@
 
 (def default-tracer
   (let [pr-val* (fn pr-val* [x]
-                  (cond 
-                    (fn? x) 
-                    (fn-signature x)
-                    (coll? x)
-                    (walk pr-val* identity x)
-                    :else x))
+                            (cond 
+                              (fn? x) 
+                              (fn-signature x)
+                              (coll? x)
+                              (walk pr-val* identity x)
+                              :else x))
         pr-val (fn [x] (pr-str (pr-val* x)))
         log-binding (fn [form init]
-                        (.groupCollapsed js/console "%c%s %c%s" 
-                                            "font-weight:bold;" (pr-str form)
-                                            "font-weight:normal;" (pr-val init)))
+                      (.groupCollapsed js/console "%c%s %c%s" 
+                                       "font-weight:bold;" 
+                                       (pr-str form)
+                                       "font-weight:normal;" 
+                                       (pr-val init)))
         log-exit (fn [exit]
-                       (.groupCollapsed js/console "=>" (pr-val exit))
-                       (.log js/console exit)
-                       (.groupEnd js/console))
+                   (.groupCollapsed js/console "=>" (pr-val exit))
+                   (.log js/console exit)
+                   (.groupEnd js/console))
         has-bindings? #{'fn*
                         `fn
                         'fn
@@ -163,8 +165,8 @@
   (let [pr-val (fn pr-val [x] x)
         log-binding (fn [form init]
                       (.groupCollapsed js/console "%c%s"
-                                        "font-weight:bold;" (pr-str form)
-                                        (pr-val init)))
+                                       "font-weight:bold;" (pr-str form)
+                                       (pr-val init)))
         log-exit (fn [exit]
                    (.log js/console "=>" (pr-val exit)))
         has-bindings? #{'fn*


### PR DESCRIPTION
This PR adds a custom tracer that works well with [cljs-devtools](https://github.com/binaryage/cljs-devtools). As you see I have a couple of commits where I tried to refactor `default-tracer` but it ended out as worse code.
