### PR TITLE
added defn- to trace-form

### DIFF
--- a/src/clairvoyant/core.clj
+++ b/src/clairvoyant/core.clj
@@ -255,7 +255,7 @@
                        (trace-fn-spec arglist body trace-data env)))]
     `(def ~name (fn ~@specs))))
 
-(defmethods trace-form ['defn `defn]
+(defmethods trace-form ['defn `defn 'defn- `defn-]
   [form env]
   (trace-defn form env))
 

--- a/src/clairvoyant/core.cljs
+++ b/src/clairvoyant/core.cljs
@@ -85,6 +85,8 @@
                         'fn
                         'defn
                         `defn
+                        'defn-
+                        `defn-
                         'defmethod
                         `defmethod
                         'deftype


### PR DESCRIPTION
Hi, I noticed that clairvoyant does not trace `defn-` forms. Here is a patch to fix it. 
