### PR TITLE
Goog.debug

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,11 +150,15 @@ programmer to trace any form they wish rather than just the special forms.
 #### Conditional tracing
 
 If you want to remove tracing on production builds, 
-`clairvoyant.core/trace-forms` will not add tracing when the `:elide-asserts`
-option (under `:compiler` options in your `project.clj` file) is set to true.
-Therefore if you set this option in your prod builds you do not need to remove 
-`clairvoyant.core/trace-forms` from your source. This technique was taken from
-the [reagent project](https://github.com/reagent-project/reagent)
+`clairvoyant.core/trace-forms` will not add tracing when `js/goog.DEBUG`
+is set to false this requires `:closure-defines {:goog.DEBUG false}`
+option (under `:compiler` options in your `project.clj` file).
+Therefore if you set this option in your prod builds you do not need to
+remove `clairvoyant.core/trace-forms` from your source. 
+
+WARNING: to set this option you do need to have `:optimizations :simple`
+or `optimizations :advanced` or else the value will not be set because
+the closure compiler does not do the substitution.
 
 ## Trace data
 

--- a/src/clairvoyant/core.clj
+++ b/src/clairvoyant/core.clj
@@ -72,16 +72,15 @@
                    (trace-form x env))))
     form))
 
-(defmacro dev?
-  "True if assertions are enabled."
-  []
-  (if *assert* true false))
+; (defmacro dev?
+;   "True if assertions are enabled."
+;   []
+;   (if *assert* true false))
 
 (defmacro trace-forms
   "Recursively trace one or more forms."
   {:arglists '([& forms] [{:keys [tracer]} & forms])}
   [& forms]
-  (if (dev?) 
     (let [opts (when (and (map? (first forms))
                           (contains? (first forms) :tracer))
                  (first forms)) 
@@ -96,8 +95,9 @@
       (binding [*tracer* tracer]
         (let [traced-forms (doall (for [form forms]
                                     (trace-form form &env)))]
-          `(do ~@traced-forms))))
-    `(do ~@forms)))
+          `(if (dev?)
+             (do ~@traced-forms)
+             (do ~@forms))))))
 
 
 ;; ---------------------------------------------------------------------

--- a/src/clairvoyant/core.clj
+++ b/src/clairvoyant/core.clj
@@ -77,6 +77,10 @@
 ;   []
 ;   (if *assert* true false))
 
+(def dev?
+   "True if assertions are enabled."
+   (vary-meta 'js/goog.DEBUG assoc :tag 'boolean))
+
 (defmacro trace-forms
   "Recursively trace one or more forms."
   {:arglists '([& forms] [{:keys [tracer]} & forms])}
@@ -95,7 +99,7 @@
       (binding [*tracer* tracer]
         (let [traced-forms (doall (for [form forms]
                                     (trace-form form &env)))]
-          `(if (dev?)
+          `(if ~dev?
              (do ~@traced-forms)
              (do ~@forms))))))
 

--- a/src/clairvoyant/core.cljs
+++ b/src/clairvoyant/core.cljs
@@ -1,6 +1,8 @@
 (ns clairvoyant.core
   (:require [clojure.walk :refer [prewalk walk]]))
 
+(defn dev? []
+  ^:boolean js/goog.DEBUG)
 ;; ---------------------------------------------------------------------
 ;; Protocols
 

--- a/src/clairvoyant/core.cljs
+++ b/src/clairvoyant/core.cljs
@@ -1,8 +1,6 @@
 (ns clairvoyant.core
   (:require [clojure.walk :refer [prewalk walk]]))
 
-(defn dev? []
-  ^:boolean js/goog.DEBUG)
 ;; ---------------------------------------------------------------------
 ;; Protocols
 


### PR DESCRIPTION
Right in our projects we have moved to explicitly changing the value of `js/goog.DEBUG` to indicate a production build.

Would you be open to changing the behaviour of clairvoyant to use this switch instead?

Sorry for the churn but we do now think this is a better more explicit way of indicating a production build.

I have tested this as well and the closure compiler does remove the dead code produced by this macro with :advanced optimizations.

Stu
